### PR TITLE
change code blocks from pink-red to blue

### DIFF
--- a/sopy/static/app.css
+++ b/sopy/static/app.css
@@ -2,3 +2,7 @@ body>footer {
     text-align: center;
     padding-top: 21px;
 }
+code {
+    color: #2d6987;
+    background-color: #f1f5f9;
+}


### PR DESCRIPTION
Now coordinates with links and the header instead of clashing with them, adds another color family to the page, keeping it from looking monochromatic.

Currently, http://sopython.com/wiki/1/ looks like this on my Mac:

---

![sopython-before](https://cloud.githubusercontent.com/assets/1776358/4144767/8b0553e2-33e8-11e4-9dcf-4398464f0883.png)

---

After the change (thanks to the Firefox developer tools), it looks like so:

---

![sopython-after](https://cloud.githubusercontent.com/assets/1776358/4144774/a514a6b6-33e8-11e4-9999-fc87a2a44978.png)

---

I looked for good candidate colors [here](http://bootswatch.com/united/), and the purple color might also be an option (although it's not terribly different from the original):

``` css
code {
    color: #5C2040;
    background-color: #FAF0F5;
}
```

as might green:

``` css
code {
    color: #2C8D3A;
    background-color: #F5FBF6;
}
```

At any rate, let me know what you think. I just get kind of ill looking at the current color scheme, and I love theming things, so I could probably keep coming up with colors all day long.

Thanks,
Matt
