### PR TITLE
add slugs to urls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Flask-SQLAlchemy==2.0
 Flask-WTF==0.10.2
 hoep==1.0.2
 itsdangerous==0.24
+inflection==0.2.1
 Jinja2==2.7.3
 Mako==1.0.0
 MarkupSafe==0.23

--- a/sopy/canon/models.py
+++ b/sopy/canon/models.py
@@ -25,7 +25,7 @@ class CanonItem(HasTags, IDModel):
 
     @property
     def detail_url(self):
-        return url_for('canon.detail', id=self.id)
+        return url_for('canon.detail', id=self)
 
     @property
     def update_url(self):

--- a/sopy/canon/views.py
+++ b/sopy/canon/views.py
@@ -21,7 +21,7 @@ def index():
     return {'items': items}
 
 
-@bp.route('/<int:id>/')
+@bp.route('/<id_slug:id>/')
 @template('canon/detail.html')
 def detail(id):
     item = CanonItem.query.get_or_404(id)

--- a/sopy/wiki/forms.py
+++ b/sopy/wiki/forms.py
@@ -1,11 +1,27 @@
 from flask_wtf import Form
+import re
 from wtforms.fields import StringField, TextAreaField, BooleanField
-from wtforms.validators import InputRequired
+from wtforms.validators import DataRequired, ValidationError
+from sopy import db
+from sopy.wiki.models import WikiPage
 
 
 class WikiPageForm(Form):
-    title = StringField(validators=[InputRequired()])
+    title = StringField(validators=[DataRequired()])
     body = TextAreaField()
+
+    space_re = re.compile(r'\s+')
+    invalid_re = re.compile(r'(^\.{1,2}$|/|%[0-9a-f]{2}|&#?[0-9a-z]+?;)', re.I)
+
+    def validate_title(self, field):
+        field.data = title = self.space_re.sub(field.data, ' ').strip()
+        match = self.invalid_re.search(title)
+
+        if match:
+            raise ValidationError('Invalid characters: "{}"'.format(match.group(1)))
+
+        if db.session.query(db.func.count(WikiPage.id)).filter(WikiPage.title == title).scalar():
+            raise ValidationError('A page with this title already exists.')
 
 
 class WikiPageEditorForm(WikiPageForm):

--- a/sopy/wiki/models.py
+++ b/sopy/wiki/models.py
@@ -6,7 +6,7 @@ from sopy.ext.models import IDModel
 
 
 class WikiPage(IDModel):
-    title = db.Column(db.String, nullable=False)
+    title = db.Column('title', db.String, nullable=False, unique=True)
     body = db.Column(db.String, nullable=False)
     updated = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
     draft = db.Column(db.Boolean, nullable=False, default=False)
@@ -15,14 +15,17 @@ class WikiPage(IDModel):
 
     author = db.relationship(User)
 
+    def __str__(self):
+        return self.title
+
     @property
     def detail_url(self):
-        return url_for('wiki.detail', id=self.id)
+        return url_for('wiki.detail', title=self.title)
 
     @property
     def update_url(self):
-        return url_for('wiki.update', id=self.id)
+        return url_for('wiki.update', title=self.title)
 
     @property
     def delete_url(self):
-        return url_for('wiki.delete', id=self.id)
+        return url_for('wiki.delete', title=self.title)

--- a/sopy/wiki/views.py
+++ b/sopy/wiki/views.py
@@ -21,20 +21,20 @@ def index():
     return {'pages': pages}
 
 
-@bp.route('/<int:id>/')
+@bp.route('/<title>/')
 @template('wiki/detail.html')
-def detail(id):
-    page = WikiPage.query.get_or_404(id)
+def detail(title):
+    page = WikiPage.query.filter(WikiPage.title == title).first_or_404()
 
     return {'page': page}
 
 
 @bp.route('/create', endpoint='create', methods=['GET', 'POST'])
-@bp.route('/<int:id>/update', methods=['GET', 'POST'])
+@bp.route('/<title>/update', methods=['GET', 'POST'])
 @template('wiki/update.html')
 @login_required
-def update(id=None):
-    page = WikiPage.query.get_or_404(id) if id is not None else None
+def update(title=None):
+    page = WikiPage.query.filter(WikiPage.title == title).first_or_404() if title is not None else None
 
     if not (page is None or page.draft or page.community):
         require_group('editor')
@@ -56,11 +56,11 @@ def update(id=None):
 
 
 
-@bp.route('/<int:id>/delete', methods=['GET', 'POST'])
+@bp.route('/<title>/delete', methods=['GET', 'POST'])
 @template('wiki/delete.html')
 @group_required('editor')
-def delete(id):
-    page = WikiPage.query.get_or_404(id)
+def delete(title):
+    page = WikiPage.query.filter(WikiPage.title == title).first_or_404()
     form = Form()
 
     if form.validate_on_submit():


### PR DESCRIPTION
This adds optional slugs to the urls for canon and wiki pages.  The format would look like "/wiki/18/cabbage-enhancement-proposals/" and the slug would be optional, similar to how Stack Overflow does it.

Could also add "strong slugs" that identify an instance without needing the id, but not sure if that's necessary.  That would add an extra form and model field to specify a custom slug that must be unique for the model.
