### PR TITLE
spelling, formatting consistency fixes

### DIFF
--- a/sopy/templates/pages/nidaba.html
+++ b/sopy/templates/pages/nidaba.html
@@ -12,7 +12,7 @@
     <p class="lead">Nidaba is a data analytics project devoted to analysing the Python questions and answers on Stack Overflow.</p>
 
     <p>Using the <a href="https://archive.org/details/stackexchange">Stack Exchange Data Dump</a> and
-       <a href="https://api.stackexchange.com/">Stack Exchange API</a> we have incredible real-time access to the Stack
+       <a href="https://api.stackexchange.com/">Stack Exchange API</a>, we have incredible real-time access to the Stack
        Overflow Python data. The <code>Python</code> tag currently has over 300,000 questions with several hundred
        more asked every day. The aim of Nidaba is to take this information and make the most that we can from it.</p>
 
@@ -21,15 +21,15 @@
     <p><a href="http://en.wikipedia.org/wiki/Nidaba">Nidaba</a> (<em>or Nisaba</em>) was the Sumerian goddess of writing,
         teaching, and the harvest. Her main role was as the scribe of the Gods and keeper of records.</p>
 
-    <p>The <a href="http://stackoverflow.com/tour">aim of Stack Overflow</a> as a whole is to produce a library to ever
+    <p>The <a href="http://stackoverflow.com/tour">aim of Stack Overflow</a> as a whole is to produce a library to every
        possible question about programming. When choosing a deity to name your project after, <em>what better one than the
         scribe of the Gods and keeper of records?</em></p>
 
-    <h3>What We Want To Do</h3>
+    <h3>What we want to do</h3>
 
-    <p>A big part of Nidaba will be analysis of data. There will be broadly too different sets of analysis: analysis that
+    <p>A big part of Nidaba will be analysis of data. There will be broadly two different sets of analysis: analysis that
        is directly actionable (i.e. finding duplicates) and analysis that is instead informative
-       (trends in the sopython data etc).</p>
+       (trends in the sopython data, etc).</p>
 
     <p>Some ideas we have going forward are:</p>
 
@@ -50,36 +50,36 @@
        we are using (or plan to use) include:
 
        <ul>
-           <li><a href="http://flask.pocoo.org/">Flask</a> - Flask is a lightweight web framework written in Python.
+           <li><a href="http://flask.pocoo.org/">Flask</a> &mdash; Flask is a lightweight web framework written in Python.
                The <a href="http:sopython.com"><b>so</b>python website</a> is built using Flask.</li>
 
-           <li><a href="http://www.mongodb.org/">MongoDB</a> - MongoDB is a  NoSQL database used to host the Stack
+           <li><a href="http://www.mongodb.org/">MongoDB</a> &mdash; MongoDB is a NoSQL database used to host the Stack
                Overflow data for Project Nidaba.</li>
 
-           <li><a href="http://www.postgresql.org/">PostgreSQL</a> - PostgreSQL is an open source object-relational
+           <li><a href="http://www.postgresql.org/">PostgreSQL</a> &mdash; PostgreSQL is an open source object-relational
                database system that is used to hold data for the <a href="http:sopython.com"><b>so</b>python website</a>.</li>
 
-           <li><a href="http://www.numpy.org/">NumPy</a> - NumPy is the fundemental package for use in numerical Python work.</li>
+           <li><a href="http://www.numpy.org/">NumPy</a> &mdash; NumPy is the fundamental package for use in numerical Python work.</li>
 
-           <li><a href="http://www.scipy.org/">SciPy</a> - SciPy is a Python-based ecosystem of open-source software for
+           <li><a href="http://www.scipy.org/">SciPy</a> &mdash; SciPy is a Python-based ecosystem of open source software for
                mathematics, science, and engineering.</li>
 
-           <li><a href="http://pandas.pydata.org/">pandas</a> - pandas is an open source library providing high-performance,
+           <li><a href="http://pandas.pydata.org/">pandas</a> &mdash; pandas is an open source library providing high-performance,
                easy-to-use data structures and data analysis tools. Pandas will be used extensively in analysing the Stack
                Overflow data for Project Nidaba.</li>
 
-           <li><a href="http://scikit-learn.org/stable/">scikit-learn</a> - scikit-learn is an open-source machine-learning
+           <li><a href="http://scikit-learn.org/stable/">scikit-learn</a> &mdash; scikit-learn is an open source machine-learning
                library for the Python programming language. scikit-learn will be used extensively in trying to analyse
                Stack Overflow questions and answers and find common trends.</li>
 
-           <li><a href="http://matplotlib.org/">matplotlib</a> - matplotlib is an extensive 2D plotting library which
+           <li><a href="http://matplotlib.org/">matplotlib</a> &mdash; matplotlib is an extensive 2D plotting library which
                can be used to help visualise the analysis.</li>
        </ul>
     </p>
 
-    <h3>How To Help</h3>
+    <h3>How To help</h3>
 
-    <p>Project Nidaba is a young project and we are welcome to your ideas, advice, and help. Please contact
+    <p>Project Nidaba is a young project and we welcome your ideas, advice, and help. Please contact
        us <a href="mailto:ffisegydd@sopython.com">by email</a> or pop into the
        <a href="http://chat.stackoverflow.com/rooms/6/python">sopython chatroom</a> if you want to chat.
 


### PR DESCRIPTION
Fixed spelling errors. The title cases were inconsistent, so those were fixed to only capitalize the first letter of each phrase (the majority of cases followed this pattern). Replaced hyphens with em-dashes in the technologies list.
