### PR TITLE
Fixing the warning for wiki and canon pages

### DIFF
--- a/sopy/templates/canon/detail.html
+++ b/sopy/templates/canon/detail.html
@@ -6,7 +6,7 @@
     <div class="row"><div class="col-md-12">
         <h2 class="page-header">{{ item.title|markdown }}</h2>
 
-        {% if item.draft %}<div class="alert alert-warning">This page is in draft mode.  Only editors and logged in users with the link may view it.</div>{% endif %}
+        {% if item.draft %}<div class="alert alert-warning">This page is in draft mode. Only editors or anyone with the link may view it.</div>{% endif %}
         {% if item.community %}<div class="alert alert-info">This page is in community mode.  Any logged in users may edit it.</div>{% endif %}
 
         <ul class="list-inline pull-right">

--- a/sopy/templates/wiki/detail.html
+++ b/sopy/templates/wiki/detail.html
@@ -4,7 +4,7 @@
     <div class="row"><div class="col-md-12">
         <h2 class="page-header">{% block title %}{{ page.title }}{% endblock %}</h2>
 
-        {% if page.draft %}<div class="alert alert-warning">This page is in draft mode.  Only editors or any logged in users with the link may view it.</div>{% endif %}
+        {% if page.draft %}<div class="alert alert-warning">This page is in draft mode. Only editors or anyone with the link may view it.</div>{% endif %}
         {% if page.community %}<div class="alert alert-info">This page is in community mode.  Any logged in users may edit it.</div>{% endif %}
 
         <ul class="list-inline pull-right">


### PR DESCRIPTION
The previous warning messages were misleading, fixing them in this PR.