### PR TITLE
rules re-design

### DIFF
--- a/sopy/templates/base.html
+++ b/sopy/templates/base.html
@@ -19,10 +19,10 @@
                 </div>
                 <div class="collapse navbar-collapse" id="base-nav-collapse">
                     <ul class="nav navbar-nav">
-                        <li class="{% block nav_wiki %}{% endblock %}"><a href="{{ url_for('wiki.index') }}">Wiki</a></li>
-                        <li class="{% block nav_canon %}{% endblock %}"><a href="{{ url_for('canon.index') }}">Common Questions</a></li>
-                        <li class="{% block nav_salad %}{% endblock %}"><a href="{{ url_for('salad.index') }}">Salad Language</a></li>
                         <li class="{% block nav_chatroom %}{% endblock %}"><a href="{{ url_for('pages.page', name='chatroom') }}">Chatroom</a></li>
+                        <li class="{% block nav_canon %}{% endblock %}"><a href="{{ url_for('canon.index') }}">Common Questions</a></li>
+                        <li class="{% block nav_wiki %}{% endblock %}"><a href="{{ url_for('wiki.index') }}">Wiki</a></li>
+                        <li class="{% block nav_salad %}{% endblock %}"><a href="{{ url_for('salad.index') }}">Salad Language</a></li>
                         <li class="{% block nav_transcript %}{% endblock %}"><a href="{{ url_for('transcript.index') }}">Transcripts</a></li>
                         {% if has_group('Dark Council') %}<li class="{% block nav_admin %}{% endblock %}"><a href="{{ url_for('admin.groups_index') }}">Admin</a></li>{% endif %}
                     </ul>
@@ -43,7 +43,7 @@
 
     <footer class="container small"><div class="row"><div class="col-md-12">
       <p>Made by the cabbage addicts from the <a href="https://chat.stackoverflow.com/rooms/6/python">Python room</a> on <a href="https://stackoverflow.com/">Stack Overflow</a>.</p>
-      <p>This site is not affiliate with Stack Overflow. Contact us via <a href="https://chat.stackoverflow.com/rooms/6/python">chat</a> or <a href="mailto:chatroom@sopython.com">email</a>.</p>
+      <p>This site is not affiliated with Stack Overflow. Contact us via <a href="https://chat.stackoverflow.com/rooms/6/python">chat</a> or <a href="mailto:chatroom@sopython.com">email</a>.</p>
       <p><a href="https://github.com/sopython/sopython-site">sopython-site v{{ __version__ }}</a></p>
     </div></div></footer>
 

--- a/sopy/templates/pages/chatroom.html
+++ b/sopy/templates/pages/chatroom.html
@@ -3,81 +3,53 @@
 {% block nav_chatroom %}active{% endblock %}
 
 {% block content %}
-    <div class="row"><div class="col-md-12">
+  <div class="row"><div class="col-md-12">
+    <h2 class="page-header">{% block title %}Chat Room{% endblock %}</h2>
 
-    <h2 class="page-header">{% block title %}Chatroom{% endblock %}</h2>
+    <p class="lead">The heart of the <b>so</b>python community is the <a href="https://chat.stackoverflow.com/rooms/6/python">Python chat room</a> on Stack Overflow. We are an active and friendly room full of Python professionals and enthusiasts who all share a common love for the language.</p>
 
-    <p class="lead">The heart of the <b>so</b>python community is the
-        <a href="http://chat.stackoverflow.com/rooms/6/python">Stack Overflow Python chatroom.</a></p>
-
-    <p>We are an active and friendly room full of Python experts and beginners who all share a common love for the language.
-       Whether you're a veteran Pythonista or looking to start learning the language you're more than welcome to join us.
-       As with any community we have our own set of rules and etiquette which are set out below, please be considerate and
-       take the time to read them.
-    </p>
-
-    <p><em>Incidentally, if you've just been greeted with the word "cbg" or "cabbage" then
-       you may want to <a href="{{ url_for('salad.index') }}">have a look here...</a></em>
-    </p>
+    <p><em>If you've been greeted with the word "cbg" or "cabbage", you may want to <a href="{{ url_for('salad.index') }}">have a look here</a>.</em></p>
 
     <p>Use our <a href="{{ url_for('spoiler.encode') }}">spoiler obfuscator</a> to link to spoilers in chat.</p>
 
-    <h2>cv-pls</h2>
-    <p>This room has its own policy as to how <code>cv-pls</code> tags should be used. Please take a moment to read it <a href="{{ url_for('wiki.detail', title='cv-pls') }}">here</a> if you wish to assist the community in clearing up the site.</p>
+    <h3>Rules</h3>
 
-    <h2>Rules</h2>
+    <p>As with any community, we have our own set of rules and etiquette. Please be considerate and take the time to read and follow them. If you are disruptive, users may not want to interact with you in the future. Room owners will use their <a href="https://meta.stackexchange.com/questions/271267/a-guide-to-moderating-chat">moderation tools</a> to keep the room on track.</p>
 
-    <ol>
-        <li><a href="http://chat.stackoverflow.com/faq#nice">Be nice.</a></li>
-        <li>No swearing.  Expletives are <a href="https://meta.stackexchange.com/a/22233/162650">not acceptable behavior</a> on any Stack Exchange site.</li>
-        <li>If nobody responds to your question, that means no-one in the room is able to help (either because they don't know,
-            or are too busy to answer right now). Please don't spam the room with further requests for help on the same question.
-            It will only annoy people and make them less likely to want to help you in future.</li>
-        <li>Especially don't use <code>@username</code> notification unless that user has already told you it's okay to ping them; <em>that's like
-            jabbing someone in the shoulder and saying "Hey! Answer me!"</em>, and will quickly mark you out as someone to be avoided.</li>
-        <li>However it is acceptable (and encouraged) to <code>@username</code> people where it assists in the flow of existing conversations.</li>
-        <li>Cute fluffy animals (especially kittens and puppies) are cool, okay!?</li>
-    </ol>
+    <ul>
+      <li><a href="https://stackoverflow.com/help/be-nice">Be nice.</a></li>
+      <li>No swearing or crude language. It is <a href="https://meta.stackexchange.com/a/22233/162650">not acceptable</a> on Stack Overflow.</li>
+      <li>If nobody responds to you, that means no one is able to right now. Don't spam the room with further requests.</li>
+      <li>Don't ping (<code>@username</code>) users unsolicited. Use pings when they assist the flow of existing conversations.</li>
+      <li><a href="https://meta.stackexchange.com/questions/57286/which-links-and-sites-are-handled-specially-in-chat">Inlined links</a>, images, and animations may be removed if they are too big or distracting. Use them sparingly.</li>
+      <li>Wait to post until you've written a complete sentence. Avoid rapid, short "stream of conciousness" messages. Avoid using abbreviated "txt spk".</li>
+      <li>Use the menu to the left of your message to edit or remove it within the two minute edit period.</li>
+      <li>We can provide help with community moderation, but continued heated or negative discussion is not healthy for the room.</li>
+      <li>Cute fluffy animals are cool, okay!?</li>
+    </ul>
 
-    <h3>Posting Question/Answer Links</h3>
+    <h4>Asking a Question</h4>
 
-    <ol>
-        <li>Do not link your recent (< 1-2 days) questions in the room. The main site is the dedicated space for posting questions,
-            and having them answered.</li>
-        <li>If you have posted a question on the main site and a significant amount of time has passed without receiving a
-            satisfying answer, then you can discuss your question in the room.</li>
-        <li>You should never simply link your question into the chat room without staying to discuss it and should usually
-            only link it when having been asked by others.</li>
-        <li>Linking questions which are not your own recently posted questions is alright as long as it serves a
-            purpose, and you are willing to discuss answering it, or are suggesting it be closed.</li>
-    </ol>
+    <ul>
+      <li>Don't ask for answers to your recent Stack Overflow questions. Those who can answer are already watching the queue on the main site.</li>
+      <li>If your question is <a href="https://stackoverflow.com/help/bounty">eligible for a bounty</a> (>= 48 hours old) and hasn't received a useful response, then you may link to it.</li>
+      <li>Ask your question directly. Avoid asking if it's okay to ask, or if anyone knows about a topic. Users may want to see your question before speaking up, and users who join later can see it.</li>
+      <li>If your code is longer than about 12 lines, use an external paste tool such as <a href="http://dpaste.com">dpaste.com</a>.</li>
+      <li><a href="{{ url_for('wiki.detail', title='An Illustrated Guide To Formatting Code In Chat') }}">Format your code.</a> Inline code should be enclosed in backticks (<code>`code`</code>). For multi-line posts, every line including empty ones must be indented by 4 spaces. Paste your code and press <code>Ctrl + K</code> or the <em>"fixed font"</em> button. Use <code>Shift + Enter</code> to insert new lines.</li>
+      <li>Ask about Python. Go to a relevant room to ask about other languages or topics, even if that room is less active.</li>
+      <li>Follow the same guidance as the main site. Accurately and concisely describe the problem. Provide a <a href="https://stackoverflow.com/help/mcve">Minimal, Complete, and Verifiable Example</a>.</li>
+      <li>Search and research before asking. Try running your code. Try using a debugger.</li>
+      <li>Chat is not a substitute for reading a tutorial or taking a class.</li>
+      <li>Don't star posts to reward users for answering your question. Your gratitude is reward enough. If your question meets Stack Overflow's standards, you may post your question there and invite the user to post an answer which you may accept.</li>
+    </ul>
 
-    <h3>Asking a question</h3>
-    <ol>
-      <li>You do not need to ask if it’s okay to ask a question.</li>
-      <li>You may ask your question without a preamble.<br />
-        For example, you do not need to say “anyone here know Django?” before asking a question about Django. Even if you
-        do, the Django experts in the room might not step forward until hearing the actual question. They may not wish
-        to commit themselves to help until they know how much effort it will entail.</li>
-      <li>Only paste code directly into chat if it is not very long.<br />
-        There is no hard limit, but about a dozen lines is acceptable. For longer code, use an external paste tool such
-        as <a href="http://dpaste.org/">dpaste</a>.</li>
-      <li>Double check that your code is properly formatted.<br />
-        For a multi-line post to retain its indentation, every line (including empty lines) must be preceded with four
-        spaces. Paste your text and indent it with <kbd>Ctrl+K</kbd>. Alternatively, press the <em>“fixed font”</em>
-        button that appears next to <em>“send”</em> and <em>“upload”</em> when your post is more than one line long.</li>
-      <li>Don’t star posts to reward users for answering your question.<br />
-        For most users, your gratitude is reward enough. Alternatively, if your question meets StackOverflow’s standards,
-        you may post your question there, and invite the answerer to make a reply which you may accept.</li>
-    </ol>
+    <h4>cv-pls</h4>
+
+    <p>You may see messages starting with <code>cv-pls</code> or similar tags. These are used to assist in community moderation. If you wish to participate, please read our <a href="{{ url_for('wiki.detail', title='cv-pls') }}">cv-pls policy</a>.</p>
 
     <h3>Contact Us</h3>
 
-    <p>We believe that the Python chatroom should be a <a href="https://www.python.org/psf/diversity/">friendly and welcoming place</a>.
-       If any behaviour in the room makes you feel uncomfortable, you can <code>@notify</code> one of the
-       <a href="http://chat.stackoverflow.com/rooms/info/6/python">room owners</a> and we'll do our best to sort it out.</p>
-    <p>If you wish to contact the sopython room owners you can also feel free to drop us an
-        <a href="mailto:chatroom@sopython.com">email</a>.</p>
-
-    </div></div>
+    <p>If any behaviour in the room makes you feel uncomfortable, you may ping (<code>@username</code>) one of the <a href="https://chat.stackoverflow.com/rooms/info/6/python">room owners</a> and we'll do our best to sort it out.</p>
+    <p>If you wish to contact the room owners privately, <a href="mailto:chatroom@sopython.com">email us</a>.</p>
+  </div></div>
 {% endblock %}


### PR DESCRIPTION
closes #156

After dropping, adding, and re-wording, there are 18 rules instead of 15. They are written more concisely so the visual weight remains about the same (the page is ~200px shorter). There are 2 groups instead of 3: general and questions (three if you count the cv-pls link).

I added a blurb about the consequences of being disruptive, including linking to what tools room owners have for moderation and why they'll use them.

Before:

![screen shot 2018-01-18 at 14 23 46-fullpage](https://user-images.githubusercontent.com/1242887/35125071-240beba6-fc5d-11e7-896c-fcf01256c21c.png)

After:

![screen shot 2018-01-20 at 13 00 34-fullpage](https://user-images.githubusercontent.com/1242887/35187934-f186155e-fde1-11e7-89bd-6c5c4e564eea.png)

