### PR TITLE
fix transcript parsing

### DIFF
--- a/sopy/transcript/forms.py
+++ b/sopy/transcript/forms.py
@@ -62,6 +62,7 @@ class UpdateTranscriptForm(FlaskForm):
     body = TextAreaField('Description')
 
     def process(self, formdata=None, obj=None, data=None, **kwargs):
+        formdata = self.meta.wrap_formdata(self, formdata)
         super().process(formdata, obj, data, **kwargs)
 
         if formdata is not None:

--- a/sopy/transcript/parser.py
+++ b/sopy/transcript/parser.py
@@ -39,7 +39,7 @@ def previous_page(current):
     # get and parse the new page
     r = requests.get(base_url.format(element['href']))
     r.raise_for_status()
-    return BeautifulSoup(r.content, 'lxml')
+    return BeautifulSoup(r.text, 'lxml')
 
 
 def next_page(current):
@@ -74,7 +74,7 @@ def next_page(current):
     # get and parse the new page
     r = requests.get(base_url.format(element['href']))
     r.raise_for_status()
-    return BeautifulSoup(r.content, 'lxml')
+    return BeautifulSoup(r.text, 'lxml')
 
 
 def page_date(page):
@@ -101,11 +101,11 @@ def get_range(start_id, end_id):
     # need to check that the range is in the same room, so fetch start and end pages
     r = requests.get(permalink_url.format(start_id))
     r.raise_for_status()
-    page = BeautifulSoup(r.content, 'lxml')
+    page = BeautifulSoup(r.text, 'lxml')
     room_href = page.find('div', id='sidebar-content').find('span', class_='room-name').a['href']
     r = requests.get(permalink_url.format(end_id))
     r.raise_for_status()
-    end_page = BeautifulSoup(r.content, 'lxml')
+    end_page = BeautifulSoup(r.text, 'lxml')
 
     if room_href != end_page.find('div', id='sidebar-content').find('span', class_='room-name').a['href']:
         raise ValueError('Start and end are in different rooms.')


### PR DESCRIPTION
For some reason BeautifulSoup stopped being able to parse the bytes returned from SO. So I'm using `r.text` instead which relies on the HTTP headers instead of detection. Probably safe since SO is well-behaved in that regard.

Also, a change to Flask-WTF affected how auto form data was populated, so needed to add another step during processing.