### PR TITLE
Fix spoiler submit

### DIFF
--- a/sopy/spoiler/forms.py
+++ b/sopy/spoiler/forms.py
@@ -1,6 +1,5 @@
 from flask_wtf import FlaskForm
 from wtforms import TextAreaField
-from wtforms.validators import InputRequired
 
 class SpoilerForm(FlaskForm):
-    message = TextAreaField(validators=[InputRequired()])
+    message = TextAreaField(validators=[])


### PR DESCRIPTION
This removes the validation on the text field to prevent the validation that is built into browsers from preventing the form submission.

The form submit would usually trigger a function that copies over the content from the fancy editor into the plain (but hidden) text field. But since the form submission is prevented, that function never runs and
never makes the form valid even if content was added.

The downside of this change is that you can submit with an empty text field but I would say that is not a real issue for users of this service.

---

I was not able to actually test this, so I would appreciate if someone could give it a try and see if it works :D Ideally, the `required` attribute should be gone on the textfield of the form.